### PR TITLE
Be/#64 [Fix] 다음 라운드 URL 전송, topic 생성 오류 

### DIFF
--- a/backend/myapp/consumers.py
+++ b/backend/myapp/consumers.py
@@ -129,7 +129,7 @@ class RoomConsumer(AsyncWebsocketConsumer):
 
                 room_num = await self.get_room_count()
 
-                await self.save_topic(title, player_id)
+                await self.save_topic(title, self.present_sub_room_id)
 
                 room = await self.get_room_by_id(self.room_id)
 
@@ -168,6 +168,7 @@ class RoomConsumer(AsyncWebsocketConsumer):
                         self.room_group_name,
                         {"type": "next_round", "message": "다음 라운드 정보 주거나 게임 종료"},
                     )
+
             elif event == "changeTitle":
                 title = data["title"]
 
@@ -304,7 +305,7 @@ class RoomConsumer(AsyncWebsocketConsumer):
             return
         present_sub_room = await sync_to_async(SubRoom.objects.get)(id=self.present_sub_room_id)
         self.present_sub_room_id = await sync_to_async(present_sub_room.get_next_id)()
-        print(self.sub_room_id,"present_sub_room :",self.present_sub_room_id)
+        #print(self.sub_room_id,"present_sub_room :",self.present_sub_room_id)
 
         # 다음 이미지 전달
         while True:
@@ -356,8 +357,8 @@ class RoomConsumer(AsyncWebsocketConsumer):
         return SubRoom.objects.filter(room=room, delete_at=None).exists()
 
     @sync_to_async
-    def save_topic(self, title, player_id):
-        sub_room = SubRoom.objects.get(id=player_id)
+    def save_topic(self, title, present_sub_room_id):
+        sub_room = SubRoom.objects.get(id=present_sub_room_id)
         topic = Topic.objects.create(title=title, url=None, sub_room=sub_room)
         return topic
 

--- a/backend/myapp/consumers.py
+++ b/backend/myapp/consumers.py
@@ -305,7 +305,6 @@ class RoomConsumer(AsyncWebsocketConsumer):
             return
         present_sub_room = await sync_to_async(SubRoom.objects.get)(id=self.present_sub_room_id)
         self.present_sub_room_id = await sync_to_async(present_sub_room.get_next_id)()
-        #print(self.sub_room_id,"present_sub_room :",self.present_sub_room_id)
 
         # 다음 이미지 전달
         while True:

--- a/backend/myapp/models.py
+++ b/backend/myapp/models.py
@@ -43,8 +43,6 @@ class SubRoom(models.Model):
     def get_next_id(self):
         next_sub_room_id = self.next_room.id
         return next_sub_room_id
-    def get_frist_player(self):
-        return
     @classmethod
     def get_first_subroom(cls, room):
         return cls.objects.filter(room=room, delete_at=None).order_by('created_at').first()

--- a/backend/myapp/models.py
+++ b/backend/myapp/models.py
@@ -40,8 +40,10 @@ class SubRoom(models.Model):
         self.delete_at = timezone.now()
         self.save()
 
-    def get_next(self):
-        return self.next_room
+    def get_next_id(self):
+        next_sub_room_id = self.next_room.id
+        return next_sub_room_id
+
     @classmethod
     def get_first_subroom(cls, room):
         return cls.objects.filter(room=room, delete_at=None).order_by('created_at').first()
@@ -65,7 +67,6 @@ class SubRoom(models.Model):
         first_player = f'플레이어 {max_number}'
 
         subroom = SubRoom.objects.create(first_player=first_player, room=room)
-
 
         if last_subroom:
             last_subroom.next_room = subroom
@@ -111,5 +112,6 @@ class Topic(models.Model):
         self.save()
 
     @classmethod
-    def get_last_topic(cls, subroom):
+    def get_last_topic(cls, subroom_id):
+        subroom = SubRoom.objects.get(id=subroom_id)
         return cls.objects.filter(sub_room=subroom, delete_at=None).order_by('-created_at').first()

--- a/backend/myapp/models.py
+++ b/backend/myapp/models.py
@@ -43,7 +43,8 @@ class SubRoom(models.Model):
     def get_next_id(self):
         next_sub_room_id = self.next_room.id
         return next_sub_room_id
-
+    def get_frist_player(self):
+        return
     @classmethod
     def get_first_subroom(cls, room):
         return cls.objects.filter(room=room, delete_at=None).order_by('created_at').first()


### PR DESCRIPTION
## 🛠️ 변경사항
**다음 라운드 URL 전송**

원인
url이 아직 채워지지 않은 상태서 값을 가지고 오고 있어다.
 
해결
url이 none 아닐때 값을 받아서 다음 라운드에 이동 시켰다.

**topic 생성 오류** 

원인 
topic 생성시 자신의 subroom 하고 있었다.

해결
present_sub_room에 topic을 생성 하도록 했다.

</br>
</br>

## ☝️ 유의사항

</br>
</br>

## 👀 참고자료

</br>
</br>

## ❗체크리스트
- [x] 하나의 메소드는 최소의 기능만 하도록 설정했나요?
- [x] 수정 가능하도록 유연하게 작성했나요?
- [x] 필요 없는 import문이나 setter 등을 삭제했나요?
- [x] 기존의 코드에 영향이 없는 것을 확인하였나요?
