### PR TITLE
BE/#90 Fix: 혼자 이름 변경 후 오류 해결

### DIFF
--- a/backend/myapp/models.py
+++ b/backend/myapp/models.py
@@ -58,7 +58,7 @@ class SubRoom(models.Model):
 
         # 이미 1개가 있다면
         if last_subroom:
-            last_player_number = int(re.search(r'\d+', last_subroom.first_player).group())
+            last_player_number = cls.objects.filter(room=room, delete_at=None).count()
             max_number = last_player_number + 1
         else:
             max_number = 1


### PR DESCRIPTION
## 🛠️ 변경사항
**원인**
room에 인원을 추가 할 때 인원의 디폴트 이름 만들어 주는 과정에서 문제가 발생

**해결**
디폴트 이름을 만들때 room의 인원을 확인하는 과정을 변경함
룸에 1명만 있는 경우 send_player_list()를 하지 않게 함

</br>
</br>

## ☝️ 유의사항

</br>
</br>

## 👀 참고자료
<img width="727" alt="스크린샷 2023-07-31 오후 3 25 55" src="https://github.com/2023-Summer-Bootcamp-Team-B/RelaySketch/assets/67044438/0f631091-3273-48c8-abeb-a7892769e5be">

</br>
</br>

## ❗체크리스트
- [x] 하나의 메소드는 최소의 기능만 하도록 설정했나요?
- [x] 수정 가능하도록 유연하게 작성했나요?
- [x] 필요 없는 import문이나 setter 등을 삭제했나요?
- [x] 기존의 코드에 영향이 없는 것을 확인하였나요?
